### PR TITLE
Update to latest Mininet; fix CR-96; fix typo in specfile

### DIFF
--- a/components/mininet/mininet.spec
+++ b/components/mininet/mininet.spec
@@ -1,11 +1,11 @@
 Name: mininet
-Version: 2.2.0
+Version: 2.2.1
 Release: 1%{?dist}
 Summary: Internet Virtualization
 
 License:  BSD
 URL: http://mininet.github.com/
-Source0: https://github.com/mininet/mininet/archive/%{version}.tar.gz  
+Source0: https://github.com/mininet/mininet/archive/mininet-%{version}.tar.gz
 Patch0: 0001-Modify-Makefile-to-work-with-rpmbuild.patch
 
 BuildRequires: python-networkx, python-devel, pyflakes, pylint, python-pep8, help2man
@@ -28,6 +28,7 @@ make install DESTDIR=${RPM_BUILD_ROOT}
 cp bin/mn ${RPM_BUILD_ROOT}/%{_bindir}
 mkdir -p ${RPM_BUILD_ROOT}/%{python_sitelib}
 cp -r mininet ${RPM_BUILD_ROOT}/%{python_sitelib}
+cp -r examples/ ${RPM_BUILD_ROOT}/%{python_sitelib}
 
 %clean
 rm -rf $RPM_BUILD_ROOT
@@ -40,6 +41,8 @@ rm -rf $RPM_BUILD_ROOT
 %{_mandir}/man*/*
 
 %changelog
+* Mon Jul 06 2015 Jay Turner <jkt@iix.net> - 2.2.0-2
+- Copy in the examples/ directory
 * Thu Jul 02 2015 John Siegrist <jsiegrist@iix.net> - 2.2.0-1
 - Added dist macro to Release
 * Mon Mar 09 2015 Arun Babu Neelicattu <abn@iix.net> - 2.2.0-1

--- a/components/mininet/sources
+++ b/components/mininet/sources
@@ -1,1 +1,1 @@
-36193ffdb7f358077f6192cb62a1a188  2.2.0.tar.gz
+a11238ee25489d3aa20f7f8aa72fca69  mininet-2.2.1.tar.gz


### PR DESCRIPTION
Signed-off-by: Jay Turner <jturner@iix.net>

* Need to include the examples/ files due to module dependencies
* Fix-up the Source0 declaration (was missing "mininet-")
* Update to latest Mininet tarball (2.2.1)