### PR TITLE
Pick up all RPM artifacts

### DIFF
--- a/build/rpms/build-components.sh
+++ b/build/rpms/build-components.sh
@@ -64,7 +64,7 @@ for COMPONENT in "${COMPONENTS[@]}"; do
             -exec rpmbuild "${RPM_BUILD_OPTS[@]}" --clean {} \; | tee ${LOG_FILE}
 
         # lets pull out the rpms created
-        find ${RPM_BUILD_RPMS} -name "${COMPONENT}*.rpm" \
+        find ${RPM_BUILD_RPMS} -name "*.rpm" \
             -exec mv {} . \;
         find ${RPM_BUILD_SRPMS} -name "${COMPONENT}*.rpm" \
             -exec mv {} . \;


### PR DESCRIPTION
Signed-off-by: Jay Turner <jturner@iix.net>

Current behavior only picks up artifacts whose name begins with ${COMPONENT}, but there are packages, and we are including one, where the SRPM and therefore the ${COMPONENT} do not appear at the front of the package name.  'python-exabgp' is a good example.  It builds "python-exabgp", "python-exabgp-debuginfo", and "exabgp" . . . the latter of which was not getting picked up as an artifact.