### PR TITLE
Adding docker-img target to provide support for generating the base docker image for cloudrouter via kickstart

### DIFF
--- a/kickstarts/Makefile
+++ b/kickstarts/Makefile
@@ -52,14 +52,40 @@ virt-img:
 	--serial file,path=$(TMP_LOG)
 	virt-cat --connect qemu:///session $(IMG_NAME) $(TMP_FILE) > $(IMG_MANIFEST)
 	xz --verbose --force $(IMG_NAME)
+
+# virt-install takes longer when done on nested KVM
+# setting max wait time to 4h
+# the output .tar.xz can be used directly in a Dockerfile or used with docker import cmd
+docker-img:
+	ksflatten -c cloudrouter-$(OS)-docker.ks -o $(TMP_KS)
+	virt-install \
+        --connect qemu:///session \
+	--name=$(TMP_NAME) \
+	--ram=2048 \
+	--cpu=host --vcpus=2 \
+	--os-type=linux \
+	--initrd-inject=$(TMP_KS) \
+	--extra-args="inst.ks=file:/$(TMP_KS) console=tty0 console=ttyS0,115200" \
+	--disk $(IMG_NAME),size=6,format=raw \
+	--location=$(OS_TREE) \
+	--nographics \
+	--noreboot \
+	--wait 300 \
+	--serial file,path=$(TMP_LOG)
+	virt-cat --connect qemu:///session $(IMG_NAME) $(TMP_FILE) > $(IMG_MANIFEST)
+	virt-tar-out -a $(IMG_NAME) / - | xz --best > $(ISO_PREFIX)-docker.tar.xz
+	echo "From scratch" > Dockerfile
+	echo "MAINTAINER Jay Turner<jturner@iix.net>" >> Dockerfile
+	echo "ADD $(ISO_PREFIX)-docker.tar.xz /" >> Dockerfile
+
 	
-all: livecd virt-img
+all: livecd virt-img docker-img
 
 # Phony targets for cleanup and similar uses
 #
 # .PHONY: clean
 
 clean:
-	sudo rm -f *.iso *.raw *.xz $(TMP_KS) *.manifest
+	sudo rm -f *.iso *.raw *.xz $(TMP_KS) *.manifest Dockerfile
 	virsh --connect qemu:///session destroy $(TMP_NAME) || true
 	virsh --connect qemu:///session undefine $(TMP_NAME) || true

--- a/kickstarts/cloudrouter-docker-base.ks
+++ b/kickstarts/cloudrouter-docker-base.ks
@@ -1,0 +1,60 @@
+# This is a minimal Fedora install designed to serve as a Docker base image. 
+#
+
+cmdline
+bootloader --disabled
+timezone --isUtc --nontp Etc/UTC
+rootpw --lock --iscrypted locked
+user --name=none
+
+keyboard us
+zerombr
+clearpart --all
+part / --size 4000 --fstype ext4
+network --bootproto=dhcp --device=link --activate --onboot=on
+shutdown
+
+%packages --excludedocs --instLangs=en --nocore --nobase
+@core --nodefaults
+bash
+rootfiles
+vim-minimal
+dnf
+dnf-yum  
+-kernel
+
+%end
+
+%post 
+
+# Generate rpm manifest file
+/usr/bin/rpm -qa > /tmp/build-rpm-manifest.txt
+
+# remove the user anaconda forces us to make
+userdel -r none
+
+LANG="en_US"
+echo "%_install_lang $LANG" > /etc/rpm/macros.image-language-conf
+
+awk '(NF==0&&!done){print "override_install_langs='$LANG'\ntsflags=nodocs";done=1}{print}' \
+    < /etc/yum.conf > /etc/yum.conf.new
+mv /etc/yum.conf.new /etc/yum.conf
+
+rm -f /usr/lib/locale/locale-archive
+
+#Setup locale properly
+localedef -v -c -i en_US -f UTF-8 en_US.UTF-8
+
+rm -rf /var/cache/yum/*
+rm -f /tmp/ks-script*
+
+#Make it easier for systemd to run in Docker container
+cp /usr/lib/systemd/system/dbus.service /etc/systemd/system/
+sed -i 's/OOMScoreAdjust=-900//' /etc/systemd/system/dbus.service
+
+#Mask mount units and getty service so that we don't get login prompt
+systemctl mask systemd-remount-fs.service dev-hugepages.mount sys-fs-fuse-connections.mount systemd-logind.service getty.target console-getty.service
+
+rm -f /etc/machine-id
+
+%end

--- a/kickstarts/cloudrouter-fedora-docker.ks
+++ b/kickstarts/cloudrouter-fedora-docker.ks
@@ -1,0 +1,16 @@
+%include cloudrouter-fedora-repo.ks
+%include cloudrouter-repo.ks
+%include cloudrouter-docker-base.ks
+
+
+%packages --excludedocs --instLangs=en --nocore --nobase
+cloudrouter-release-fedora
+cloudrouter-release-fedora-notes
+%end
+
+
+%post
+# install rpm gpg keys
+/usr/bin/rpm --import /etc/pki/rpm-gpg/RPM-GPG-KEY-*
+
+%end

--- a/kickstarts/cloudrouter-repo.ks
+++ b/kickstarts/cloudrouter-repo.ks
@@ -1,1 +1,1 @@
-repo --name=cloudrouter --baseurl=https://repo.cloudrouter.org/repo/fedora/$releasever/$basearch/
+repo --name=cloudrouter --baseurl=https://repo.cloudrouter.org/repo/fedora/2/x86_64/


### PR DESCRIPTION
Adding docker-img target to provide support for generating the base docker image for cloudrouter via kickstart. The target also generates a sample Dockerfile that can be used to build the container and push it to the docker hub registry.