### PR TITLE
Updated Quagga RPM to better adopt to CloudRouter

### DIFF
--- a/components/quagga/quagga-pimd-service-and-init.patch
+++ b/components/quagga/quagga-pimd-service-and-init.patch
@@ -1,0 +1,120 @@
+diff --git a/redhat/Makefile.am b/redhat/Makefile.am
+index c83e959..4ec15d9 100644
+--- a/redhat/Makefile.am
++++ b/redhat/Makefile.am
+@@ -3,4 +3,4 @@ EXTRA_DIST = babeld.init babeld.service bgpd.init bgpd.service isisd.init \
+ 	isisd.service ospf6d.init ospf6d.service ospfd.init ospfd.service \
+ 	quagga.logrotate quagga.pam quagga.pam.stack quagga.spec \
+ 	quagga.sysconfig ripd.init ripd.service ripngd.init ripngd.service \
+-	watchquagga.init zebra.init zebra.service
++	watchquagga.init pimd.init pimd.service zebra.init zebra.service
+diff --git a/redhat/pimd.init b/redhat/pimd.init
+new file mode 100644
+index 0000000..49f9075
+--- /dev/null
++++ b/redhat/pimd.init
+@@ -0,0 +1,72 @@
++#!/bin/bash
++# chkconfig: - 16 84
++# config: /etc/quagga/pimd.conf
++
++### BEGIN INIT INFO
++# Provides: pimd
++# Short-Description: PIM multicast routing engine
++# Description: PIM routing engine for use with Zebra
++### END INIT INFO
++
++# source function library
++. /etc/rc.d/init.d/functions
++
++# Get network config
++. /etc/sysconfig/network
++
++# quagga command line options
++. /etc/sysconfig/quagga
++
++RETVAL=0
++PROG="pimd"
++cmd=pimd
++LOCK_FILE=/var/lock/subsys/pimd
++CONF_FILE=/etc/quagga/pimd.conf
++
++case "$1" in
++  start)
++	# Check that networking is up.
++	[ "${NETWORKING}" = "no" ] && exit 1
++
++	# The process must be configured first.
++	[ -f $CONF_FILE ] || exit 6
++	if [ `id -u` -ne 0 ]; then
++		echo $"Insufficient privilege" 1>&2
++		exit 4
++	fi
++
++	echo -n $"Starting $PROG: "
++	daemon $cmd -d $PIMD_OPTS -f $CONF_FILE
++	RETVAL=$?
++	[ $RETVAL -eq 0 ] && touch $LOCK_FILE
++	echo
++	;;
++  stop)
++	echo -n $"Shutting down $PROG: "
++	killproc $cmd
++	RETVAL=$?
++	[ $RETVAL -eq 0 ] && rm -f $LOCK_FILE
++	echo
++	;;
++  restart|reload|force-reload)
++	$0 stop
++	$0 start
++	RETVAL=$?
++	;;
++  condrestart|try-restart)
++	if [ -f $LOCK_FILE ]; then
++		$0 stop
++		$0 start
++	fi
++	RETVAL=$?
++	;;
++  status)
++	status $cmd
++	RETVAL=$?
++	;;
++  *)
++	echo $"Usage: $0 {start|stop|restart|reload|force-reload|condrestart|try-restart|status}"
++	exit 2
++esac
++
++exit $RETVAL
+diff --git a/redhat/pimd.service b/redhat/pimd.service
+new file mode 100644
+index 0000000..d62fe64
+--- /dev/null
++++ b/redhat/pimd.service
+@@ -0,0 +1,14 @@
++[Unit]
++Description=PIM multicast routing engine
++BindTo=zebra.service
++After=syslog.target network.target zebra.service
++ConditionPathExists=/etc/quagga/pimd.conf
++
++[Service]
++Type=forking
++EnvironmentFile=/etc/sysconfig/quagga
++ExecStart=/usr/sbin/pimd -d $PIMD_OPTS -f /etc/quagga/pimd.conf
++Restart=on-abort
++
++[Install]
++WantedBy=network.target
+diff --git a/redhat/quagga.sysconfig b/redhat/quagga.sysconfig
+index 4d6ec5a..6d219b0 100644
+--- a/redhat/quagga.sysconfig
++++ b/redhat/quagga.sysconfig
+@@ -8,6 +8,7 @@ OSPF6D_OPTS="-A ::1"
+ OSPFD_OPTS="-A 127.0.0.1"
+ RIPD_OPTS="-A 127.0.0.1"
+ RIPNGD_OPTS="-A ::1"
++PIMD_OPTS="-A 127.0.0.1"
+ ZEBRA_OPTS="-A 127.0.0.1"
+ 
+ # Watchquagga configuration for LSB initscripts

--- a/components/quagga/quagga.spec
+++ b/components/quagga/quagga.spec
@@ -1,3 +1,6 @@
+%define with_pimd   0
+%define with_fpm    1
+
 %define quagga_uid  92
 %define quagga_gid  92
 %define vty_group   quaggavt
@@ -7,7 +10,7 @@
 
 Name: quagga
 Version: 0.99.24.1
-Release: 3%{?dist}
+Release: 4%{?dist}
 Summary: Routing daemon
 License: GPLv2+
 Group: System Environment/Daemons
@@ -15,6 +18,9 @@ URL: http://www.quagga.net
 Source0: http://download.savannah.gnu.org/releases/quagga/%{name}-%{version}.tar.xz
 Source1: quagga-filter-perl-requires.sh
 Source2: quagga-tmpfs.conf
+%if %with_pimd
+Source3: quagga-pimd-service-and-init.patch
+%endif
 BuildRequires: systemd
 BuildRequires: net-snmp-devel
 BuildRequires: texinfo libcap-devel texi2html
@@ -28,6 +34,9 @@ Obsoletes: quagga-sysvinit
 
 Patch0: 0001-systemd-change-the-WantedBy-target.patch
 Patch1: 0001-zebra-raise-the-privileges-before-calling-socket.patch
+%if %with_pimd
+Patch2: quagga-pimd-service-and-init.patch
+%endif
 
 %define __perl_requires %{SOURCE1}
 
@@ -36,8 +45,8 @@ Quagga is free software that operates TCP/IP-based routing protocols. It takes
 a multi-server and multi-threaded approach to resolving the current complexity
 of the Internet.
 
-Quagga supports Babel, BGP4, BGP4+, BGP4-, IS-IS (experimental), OSPFv2,
-OSPFv3, RIPv1, RIPv2, and RIPng.
+Quagga supports BGP4, BGP4+, BGP4-, IS-IS (experimental), OSPFv2,
+OSPFv3, PIM RIPv1, RIPv2, and RIPng.
 
 Quagga is intended to be used as a Route Server and a Route Reflector. It is
 not a toolkit; it provides full routing power under a new architecture.
@@ -66,6 +75,9 @@ developing OSPF-API and quagga applications.
 
 %patch0 -p1
 %patch1 -p1
+%if %with_pimd
+%patch2 -p1
+%endif
 
 %build
 %configure \
@@ -75,6 +87,9 @@ developing OSPF-API and quagga applications.
     --localstatedir=%{_localstatedir}/run/quagga \
     --enable-ipv6=yes \
     --enable-isisd=yes \
+%if %with_pimd
+    --enable-pimd=yes \
+%endif
     --enable-snmp=agentx \
     --enable-multipath=64 \
     --enable-opaque-lsa \
@@ -87,7 +102,13 @@ developing OSPF-API and quagga applications.
     --enable-vty-group=%vty_group \
     --enable-rtadv \
     --disable-exampledir \
-    --enable-netlink
+    --enable-netlink \
+%if %with_fpm
+    --enable-tcp-zebra \
+    --enable-fpm \
+%endif
+    --enable-gcc-rdynamic \
+    --with-pkg-extra-version=-CloudRouter-Edition
 
 make %{?_smp_mflags} MAKEINFO="makeinfo --no-split" CFLAGS="%{optflags} -fno-strict-aliasing"
 
@@ -110,9 +131,11 @@ install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/isisd.service %{buildro
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/ripd.service %{buildroot}%{_unitdir}/ripd.service
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/ospfd.service %{buildroot}%{_unitdir}/ospfd.service
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/bgpd.service %{buildroot}%{_unitdir}/bgpd.service
-install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/babeld.service %{buildroot}%{_unitdir}/babeld.service
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/ospf6d.service %{buildroot}%{_unitdir}/ospf6d.service
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/ripngd.service %{buildroot}%{_unitdir}/ripngd.service
+%if %with_pimd
+install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/pimd.service %{buildroot}%{_unitdir}/pimd.service
+%endif
 
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/quagga.sysconfig %{buildroot}/etc/sysconfig/quagga
 install -p -m 644 %{_builddir}/%{name}-%{version}/redhat/quagga.logrotate %{buildroot}/etc/logrotate.d/quagga
@@ -137,9 +160,11 @@ getent passwd quagga >/dev/null 2>&1 || useradd -u %quagga_uid -g %quagga_gid -M
 %systemd_post ripd.service
 %systemd_post ospfd.service
 %systemd_post bgpd.service
-%systemd_post babeld.service
 %systemd_post ospf6d.service
 %systemd_post ripngd.service
+%if %with_pimd
+%systemd_post pimd.service
+%endif
 
 if [ -f %{_infodir}/%{name}.inf* ]; then
     install-info %{_infodir}/quagga.info %{_infodir}/dir || :
@@ -151,12 +176,48 @@ if [ ! -e %{_sysconfdir}/quagga/zebra.conf ]; then
     chown quagga:quagga %{_sysconfdir}/quagga/zebra.conf
     chmod 640 %{_sysconfdir}/quagga/zebra.conf
 fi
-
 if [ ! -e %{_sysconfdir}/quagga/vtysh.conf ]; then
     touch %{_sysconfdir}/quagga/vtysh.conf
     chmod 640 %{_sysconfdir}/quagga/vtysh.conf
     chown quagga:%{vty_group} %{_sysconfdir}/quagga/vtysh.conf
 fi
+if [ ! -e %{_sysconfdir}/quagga/bgpd.conf ]; then
+    touch %{_sysconfdir}/quagga/bgpd.conf
+    chmod 640 %{_sysconfdir}/quagga/bgpd.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/bgpd.conf
+fi
+if [ ! -e %{_sysconfdir}/quagga/ospfd.conf ]; then
+    touch %{_sysconfdir}/quagga/ospfd.conf
+    chmod 640 %{_sysconfdir}/quagga/ospfd.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/ospfd.conf
+fi
+if [ ! -e %{_sysconfdir}/quagga/ospf6d.conf ]; then
+    touch %{_sysconfdir}/quagga/ospf6d.conf
+    chmod 640 %{_sysconfdir}/quagga/ospf6d.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/ospf6d.conf
+fi
+if [ ! -e %{_sysconfdir}/quagga/isisd.conf ]; then
+    touch %{_sysconfdir}/quagga/isisd.conf
+    chmod 640 %{_sysconfdir}/quagga/isisd.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/isisd.conf
+fi
+if [ ! -e %{_sysconfdir}/quagga/ripd.conf ]; then
+    touch %{_sysconfdir}/quagga/ripd.conf
+    chmod 640 %{_sysconfdir}/quagga/ripd.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/ripd.conf
+fi
+if [ ! -e %{_sysconfdir}/quagga/ripngd.conf ]; then
+    touch %{_sysconfdir}/quagga/ripngd.conf
+    chmod 640 %{_sysconfdir}/quagga/ripngd.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/ripngd.conf
+fi
+%if %with_pimd
+if [ ! -e %{_sysconfdir}/quagga/pimd.conf ]; then
+    touch %{_sysconfdir}/quagga/pimd.conf
+    chmod 640 %{_sysconfdir}/quagga/pimd.conf
+    chown quagga:quagga %{_sysconfdir}/quagga/pimd.conf
+fi
+%endif
 
 %postun
 %systemd_postun_with_restart zebra.service
@@ -164,9 +225,11 @@ fi
 %systemd_postun_with_restart ripd.service
 %systemd_postun_with_restart ospfd.service
 %systemd_postun_with_restart bgpd.service
-%systemd_postun_with_restart babeld.service
 %systemd_postun_with_restart ospf6d.service
 %systemd_postun_with_restart ripngd.service
+%if %with_pimd
+%systemd_postun_with_restart pimd.service
+%endif
 
 if [ -f %{_infodir}/%{name}.inf* ]; then
     install-info --delete %{_infodir}/quagga.info %{_infodir}/dir || :
@@ -178,9 +241,11 @@ fi
 %systemd_preun ripd.service
 %systemd_preun ospfd.service
 %systemd_preun bgpd.service
-%systemd_preun babeld.service
 %systemd_preun ospf6d.service
 %systemd_preun ripngd.service
+%if %with_pimd
+%systemd_preun pimd.service
+%endif
 
 %files
 %defattr(-,root,root)
@@ -190,7 +255,6 @@ fi
 %doc ripd/ripd.conf.sample
 %doc bgpd/bgpd.conf.sample*
 %doc ospfd/ospfd.conf.sample
-%doc babeld/babeld.conf.sample
 %doc ospf6d/ospf6d.conf.sample
 %doc ripngd/ripngd.conf.sample
 %doc doc/quagga.html
@@ -227,5 +291,14 @@ fi
 %{_includedir}/quagga/ospfd/*.h
 
 %changelog
+* Sat Jun 11 2015 Martin Winter <mwinter@opensourcerouting.org> 0.99.24.1-4
+- Added conditional PIMd (disabled by default as it's experimental) to SPEC
+- Added conditional FPM interface (enabled by default) to SPEC
+- Removed Babel (Was removed just after 0.99.24.1 from Quagga Distribution
+  for licensing issues)
+- Marked Quagga Version as CloudRouter edition
+- forced enable-gcc-rdynamic to make sure to improve chances for
+  tracebacks in crashes
+
 * Mon May 4 2015 Jay Turner <jturner@iix.net> - 0.99.24.1
-Initial build
+- Initial build


### PR DESCRIPTION
Updated quagga RPM for CloudRouter.
===

- Added conditional PIMd (disabled by default) to SPEC
- Added conditional FPM interface (enabled by default) to SPEC
- Removed Babel (Was removed just after 0.99.24.1 from Quagga Distribution
  for licensing issues)
- Marked Quagga Version as CloudRouter edition
- forced enable-gcc-rdynamic to make sure to improve chances for
  tracebacks in crashes

I've added PIMd (disabled) at this time to make it easier to enable if there is a request later,
but I suggest to keep it off as Quagga 0.99.24 just got PIM added and it's expected to be
broken.

The "FPM" IS the FIB Push Manager which is used by some SDN applications to get
the routing table out of Quagga. For CloudRouter it may make sense to have this enabled.

Also updated spec to create empty conf files for all the daemons as they won't start without
at least an empty file. Quagga processes are still disabled by default.

Other changes should be easy to understand.
