### PR TITLE
ami fedora fixes

### DIFF
--- a/kickstarts/cloudrouter-fedora-ami.ks
+++ b/kickstarts/cloudrouter-fedora-ami.ks
@@ -3,3 +3,7 @@
 %packages
 %include common/ami-package-list
 %end
+
+%post
+rm -f /etc/shadow-
+%end

--- a/kickstarts/common/cloudrouter-base.ks
+++ b/kickstarts/common/cloudrouter-base.ks
@@ -7,7 +7,7 @@ keyboard --vckeymap=us --xlayouts='us'
 timezone America/New_York --isUtc --nontp
 
 # setup authentication for the system
-auth --useshadow --passalgo=sha512
+auth --disableshadow --passalgo=sha512
 
 # enable SELinux because that is the way we roll
 selinux --enforcing


### PR DESCRIPTION
Signed-off-by: ckannan <kannan.chandrasekar@gmail.com>

This fix is to disable /etc/shadow based on security review from amazon to host our AMIs in the Marketplace.